### PR TITLE
Jquery Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm test
 ## Functional tests
 ```
 ./node_modules/selenium-standalone/bin/selenium-standalone start
-./node_modules/.bin/intern-runner config=tests/intern
+./node_modules/.bin/intern-client config=tests/intern
 ```
 
 ## Build

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     ],
     "dependencies": {},
     "devDependencies": {
-        "jquery": "~2.1.3",
+        "jquery": "3.0.0",
         "requirejs": "~2.1.17"
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "gulp": "^3.8.11",
         "gulp-babel": "^5.1.0",
         "intern": "^2.2.2",
-        "jquery": "^2.1.3",
+        "jquery": "3.0.0",
         "requirejs": "^2.1.17",
         "selenium-standalone": "^4.4.0"
     },


### PR DESCRIPTION
This project uses jQuery as a dev-dependency only. Version 2.1.3 of jQuery has a known vulnerability. This PR upgrades the dependency to jQuery 3.0.0. 

Unit and functional tests passing as expected.